### PR TITLE
replaced apostrophe with single quotation mark

### DIFF
--- a/projects/ngx-angular-material-hijri-adapter/src/lib/adapter/ngx-angular-material-hijri-adapter.service.ts
+++ b/projects/ngx-angular-material-hijri-adapter/src/lib/adapter/ngx-angular-material-hijri-adapter.service.ts
@@ -183,7 +183,7 @@ export class NgxAngularMaterialHijriAdapterService extends DateAdapter<Moment> {
   private _updateMomentLocales() {
     const iMonthNamesEn = {
       iMonths:
-        `Muharram_Safar_Rabi' al-Awwal_Rabi' al-Thani_Jumada al-Ula_Jumada al-Alkhirah_Rajab_Sha’ban_Ramadhan_Shawwal_Thul-Qi’dah_Thul-Hijjah`.split(
+        `Muharram_Safar_Rabi’ al-Awwal_Rabi’ al-Thani_Jumada al-Ula_Jumada al-Alkhirah_Rajab_Sha’ban_Ramadhan_Shawwal_Thul-Qi’dah_Thul-Hijjah`.split(
           '_'
         ),
       iMonthsShort:
@@ -191,7 +191,7 @@ export class NgxAngularMaterialHijriAdapterService extends DateAdapter<Moment> {
           '_'
         ),
       months:
-        `Muharram_Safar_Rabi' al-Awwal_Rabi' al-Thani_Jumada al-Ula_Jumada al-Alkhirah_Rajab_Sha’ban_Ramadhan_Shawwal_Thul-Qi’dah_Thul-Hijjah`.split(
+        `Muharram_Safar_Rabi’ al-Awwal_Rabi’ al-Thani_Jumada al-Ula_Jumada al-Alkhirah_Rajab_Sha’ban_Ramadhan_Shawwal_Thul-Qi’dah_Thul-Hijjah`.split(
           '_'
         ),
       monthsShort:


### PR DESCRIPTION
Replace apostrophes with single quotation marks for month names in SQL queries

The month names in the SQL queries were originally delimited by apostrophes, causing parser errors during saving. This PR replaces the apostrophes with single quotation marks to resolve the syntax issue.

**Changes:**
- Modified the month names to use single quotation marks instead of apostrophes in the SQL queries for compatibility and to avoid parser errors during saving.

**Affected files:**
- `ngx-angular-material-hijri-adapter.service.ts`

**Details:**
In the months array defined in `ngx-angular-material-hijri-adapter.service.ts` , the month names were originally delimited by apostrophes. However, this caused parser errors during SQL query execution. To resolve this issue and ensure compatibility, the apostrophes were replaced with single quotation marks.

_The affected files have been updated accordingly to reflect this change._
